### PR TITLE
Improve reducer, store and slice types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Doc as YDoc, transact } from 'yjs';
-import { Reducer, Store } from 'redux';
+import { AnyAction, Reducer, Store } from 'redux';
 import { patchStore, SET_STATE_FROM_YJS_ACTION } from './patchRedux';
 import { toSharedType } from './toSharedType';
 import { patchYjs } from './patchYjs';
@@ -64,11 +64,11 @@ export const bind = (yDoc: YDoc, store: Store, sliceName: string) => {
 
 /** @desc This is a utility function to enhance an existing reducer to react to the actions dispatched that are meant to set the state of the redux slice on incoming changes from yjs. */
 export const enhanceReducer =
-  (currentReducer: Reducer): Reducer =>
-  (state, action) => {
-    if (action?.type === SET_STATE_FROM_YJS_ACTION) {
-      return action.payload === undefined ? state : action.payload;
-    } else {
-      return currentReducer(state, action);
-    }
-  };
+  <T,>(currentReducer: Reducer<T, AnyAction>): Reducer<T, AnyAction> =>
+    (state, action) => {
+      if (action?.type === SET_STATE_FROM_YJS_ACTION) {
+        return action.payload === undefined ? state : action.payload;
+      } else {
+        return currentReducer(state, action);
+      }
+    };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,10 @@ export const ROOT_MAP_NAME = '__ReduxYjsBindingsRootMap';
  * @param store The redux store containing the values that should be synced.
  * @param sliceName The name of the redux-subtree (slice) that contains the values.
  * */
-export const bind = (yDoc: YDoc, store: Store, sliceName: string) => {
+export const bind = <T extends { [key in string]: any }, K extends keyof T & string>(
+  yDoc: YDoc, 
+  store: Store<T>, 
+  sliceName: K) => {
   const rootMap = yDoc.getMap(ROOT_MAP_NAME);
   const state = store.getState()[sliceName];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Doc as YDoc, transact } from 'yjs';
-import { AnyAction, Reducer, Store } from 'redux';
+import { Reducer, Store } from 'redux';
 import { patchStore, SET_STATE_FROM_YJS_ACTION } from './patchRedux';
 import { toSharedType } from './toSharedType';
 import { patchYjs } from './patchYjs';
@@ -16,9 +16,9 @@ export const ROOT_MAP_NAME = '__ReduxYjsBindingsRootMap';
  * @param store The redux store containing the values that should be synced.
  * @param sliceName The name of the redux-subtree (slice) that contains the values.
  * */
-export const bind = <T extends { [key in string]: any }, K extends keyof T & string>(
+export const bind = <S extends { [key in string]: any }, K extends keyof S & string>(
   yDoc: YDoc, 
-  store: Store<T>, 
+  store: Store<S>, 
   sliceName: K) => {
   const rootMap = yDoc.getMap(ROOT_MAP_NAME);
   const state = store.getState()[sliceName];
@@ -67,7 +67,7 @@ export const bind = <T extends { [key in string]: any }, K extends keyof T & str
 
 /** @desc This is a utility function to enhance an existing reducer to react to the actions dispatched that are meant to set the state of the redux slice on incoming changes from yjs. */
 export const enhanceReducer =
-  <T,>(currentReducer: Reducer<T, AnyAction>): Reducer<T, AnyAction> =>
+  <S>(currentReducer: Reducer<S>): Reducer<S> =>
     (state, action) => {
       if (action?.type === SET_STATE_FROM_YJS_ACTION) {
         return action.payload === undefined ? state : action.payload;


### PR DESCRIPTION
#### [Commit 1](https://github.com/lscheibel/redux-yjs-bindings/commit/856ea96b0ef5687d8ffba46a06a2eb0d78c92732)
Improves reducer types. Before this change, `state.getState().reducerName` had an `any` type. Now, the proper type is returned:

```ts
export const store = configureStore({
  reducer: {
    counter: enhanceReducer(counterReducer),
  },
});
store.getState().counter // Type is 'CounterState', not 'any'
```

#### [Commit 2](https://github.com/lscheibel/redux-yjs-bindings/commit/902434034cda03c9dd95dd018aaa196a417698a9)
Improves store and slice types. Before this change, `bind(yDoc, store, 'somerandomstring')` would not return an error. Now, it does:

```ts
export const store = configureStore({
  reducer: {
    counter: enhanceReducer(counterReducer),
  },
});
bind(yDoc, store, 'somerandomstring'); // Error: Argument of type '"somerandomstring"' is not assignable to parameter of type '"counter"'
```